### PR TITLE
Bug fix.

### DIFF
--- a/keras_self_attention/seq_self_attention.py
+++ b/keras_self_attention/seq_self_attention.py
@@ -169,7 +169,7 @@ class SeqSelfAttention(keras.layers.Layer):
             lower = K.expand_dims(lower, axis=-1)
             upper = lower + self.attention_width
             indices = K.expand_dims(K.arange(0, input_len), axis=0)
-            e -= 10000.0 * (K.cast(indices < lower, K.floatx()) * K.cast(upper <= indices, K.floatx()))
+            e -= 10000.0 * (1 - K.cast(indices >= lower, K.floatx()) * K.cast(upper > indices, K.floatx()))
         if mask is not None:
             mask = K.expand_dims(K.cast(mask, K.floatx()), axis=-1)
             e -= 10000.0 * ((1.0 - mask) * (1.0 - K.permute_dimensions(mask, (0, 2, 1))))


### PR DESCRIPTION
Consider a small example with seq_length 5.

You will currently get:

```
>>> K.cast(indices < lower, K.floatx()) * K.cast(upper <= indices, K.floatx()) # Current implementation
<tf.Tensor: shape=(5, 5), dtype=float32, numpy=
array([[0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0.]], dtype=float32)>
```

... which is of course not what we want. With this change we get

```
>>> 1 - K.cast(indices >= lower, K.floatx()) * K.cast(upper > indices, K.floatx())
<tf.Tensor: shape=(5, 5), dtype=float32, numpy=
array([[0., 0., 1., 1., 1.],
       [0., 0., 0., 1., 1.],
       [1., 0., 0., 0., 1.],
       [1., 1., 0., 0., 0.],
       [1., 1., 1., 0., 0.]], dtype=float32)>
```

and we get the off-diagonal penalized correctly.